### PR TITLE
change defaultMapType key to string

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -234,7 +234,7 @@ type decoder struct {
 var (
 	mapItemType    = reflect.TypeOf(MapItem{})
 	durationType   = reflect.TypeOf(time.Duration(0))
-	defaultMapType = reflect.TypeOf(map[interface{}]interface{}{})
+	defaultMapType = reflect.TypeOf(map[string]interface{}{})
 	ifaceType      = defaultMapType.Elem()
 	timeType       = reflect.TypeOf(time.Time{})
 	ptrTimeType    = reflect.TypeOf(&time.Time{})


### PR DESCRIPTION
Change the defaultMapType from map[interface{}]interface{} to map[string]interface{}. This is to allow yaml imported into a generic map to be converted to JSON (JSON does not support non-string keys). This issue is well documented here: https://github.com/go-yaml/yaml/issues/139
