### PR TITLE
Parameterized omit empty

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -33,11 +33,13 @@ type encoder struct {
 	flow    bool
 	// doneInit holds whether the initial stream_start_event has been
 	// emitted.
-	doneInit bool
+	doneInit  bool
+	omitEmpty bool
 }
 
 func newEncoder() *encoder {
 	e := &encoder{}
+	e.omitEmpty = true
 	yaml_emitter_initialize(&e.emitter)
 	yaml_emitter_set_output_string(&e.emitter, &e.out)
 	yaml_emitter_set_unicode(&e.emitter, true)
@@ -46,6 +48,7 @@ func newEncoder() *encoder {
 
 func newEncoderWithWriter(w io.Writer) *encoder {
 	e := &encoder{}
+	e.omitEmpty = true
 	yaml_emitter_initialize(&e.emitter)
 	yaml_emitter_set_output_writer(&e.emitter, w)
 	yaml_emitter_set_unicode(&e.emitter, true)
@@ -218,7 +221,7 @@ func (e *encoder) structv(tag string, in reflect.Value) {
 			} else {
 				value = in.FieldByIndex(info.Inline)
 			}
-			if (info.OmitEmpty || AlwaysOmitEmpty) && isZero(value) {
+			if (info.OmitEmpty || e.omitEmpty) && isZero(value) {
 				continue
 			}
 			e.marshal("", reflect.ValueOf(info.Key))

--- a/yaml.go
+++ b/yaml.go
@@ -89,9 +89,6 @@ func UnmarshalStrict(in []byte, out interface{}) (err error) {
 	return unmarshal(in, out, true)
 }
 
-// AlwaysOmitEmpty will always omit empty fields if true.
-var AlwaysOmitEmpty = true
-
 // A Decorder reads and decodes YAML values from an input stream.
 type Decoder struct {
 	strict bool
@@ -234,6 +231,10 @@ func (e *Encoder) Encode(v interface{}) (err error) {
 	defer handleErr(&err)
 	e.encoder.marshalDoc("", reflect.ValueOf(v))
 	return nil
+}
+
+func (e *Encoder) SetOmitEmpty(omitEmpty bool) {
+	e.encoder.omitEmpty = omitEmpty
 }
 
 // Close closes the encoder by writing any remaining data.


### PR DESCRIPTION
Changes the AlwaysOmitEmpty from a global to a parameter, so we can preserved empty if needed (default remains the same).